### PR TITLE
fix(discord): stop receiving guild messages

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -13,7 +13,6 @@ export const client = new Client({
     },
     intents: [
         IntentsBitField.Flags.Guilds,
-        IntentsBitField.Flags.GuildMessages,
         IntentsBitField.Flags.GuildMessageReactions,
         IntentsBitField.Flags.GuildVoiceStates,
         IntentsBitField.Flags.DirectMessages,


### PR DESCRIPTION
## Root cause

The bot subscribes to GuildMessages even though its message-create handler only responds to direct messages. On busy guilds, this sends every guild message through discord.js, causing unnecessary event processing and cache population that grows with usage.

## Change

Remove the GuildMessages intent while retaining DirectMessages for the DM response and GuildMessageReactions for timer reaction controls.

## Validation

- npm run build
- Focused runtime intent check: directMessages=true, guildMessageReactions=true, guildMessages=false
- git diff --check