### PR TITLE
fix(timer): prevent overlapping guild ticks

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "start": "node .",
     "dev": "tsc-watch --onSuccess \"node .\"",
-    "build": "tsc"
+    "build": "tsc",
+    "test": "npm run build && node --test"
   },
   "devDependencies": {
     "@tsconfig/node22": "22.0.6",

--- a/src/timerLoop.ts
+++ b/src/timerLoop.ts
@@ -47,16 +47,24 @@ async function tick() {
     const time = getTime();
     if (time !== prevTickTime) {
         const timers = await timerRepo.getAll();
-        timers.filter((timer): timer is Timer => timer !== undefined).forEach((timer) => scheduleTimerTick(timer, time));
+        timers
+            .filter((timer): timer is Timer => timer !== undefined)
+            .forEach((timer) => void scheduleTimerTick(timer, time));
     }
     prevTickTime = time;
 }
 
-function scheduleTimerTick(timer: Timer, now: number): void {
+async function scheduleTimerTick(timer: Timer, now: number): Promise<void> {
     const timerTick = timerTickRunner.run(timer.guildId, () => tickTimer(timer, now));
-    void timerTick?.catch((error) => {
+    if (timerTick === undefined) {
+        return;
+    }
+
+    try {
+        await timerTick;
+    } catch (error) {
         logger.error(timer.guildId, new Error(`Timer tick failed\n${error}`));
-    });
+    }
 }
 
 /**

--- a/src/timerLoop.ts
+++ b/src/timerLoop.ts
@@ -12,6 +12,7 @@ import { updateStatusMessage } from "./services/statusMessage";
 import { getNextAthleteIndex, stopTimer } from "./services/timer";
 import { speakCommand } from "./speak";
 import { Timer } from "./types";
+import { ExclusiveTaskRunner } from "./util/exclusiveTaskRunner";
 import { getVoiceConnection } from "./util/getVoiceConnection";
 import { getTime } from "./util/time";
 
@@ -40,13 +41,22 @@ async function scheduleTick() {
 }
 
 let prevTickTime: number | undefined;
+const timerTickRunner = new ExclusiveTaskRunner<string>();
+
 async function tick() {
     const time = getTime();
     if (time !== prevTickTime) {
         const timers = await timerRepo.getAll();
-        timers.filter((timer): timer is Timer => timer !== undefined).forEach((timer) => tickTimer(timer, time));
+        timers.filter((timer): timer is Timer => timer !== undefined).forEach((timer) => scheduleTimerTick(timer, time));
     }
     prevTickTime = time;
+}
+
+function scheduleTimerTick(timer: Timer, now: number): void {
+    const timerTick = timerTickRunner.run(timer.guildId, () => tickTimer(timer, now));
+    void timerTick?.catch((error) => {
+        logger.error(timer.guildId, new Error(`Timer tick failed\n${error}`));
+    });
 }
 
 /**

--- a/src/util/exclusiveTaskRunner.ts
+++ b/src/util/exclusiveTaskRunner.ts
@@ -1,0 +1,18 @@
+export class ExclusiveTaskRunner<Key> {
+    readonly #activeTasks = new Map<Key, symbol>();
+
+    run(key: Key, task: () => Promise<void>): Promise<void> | undefined {
+        if (this.#activeTasks.has(key)) {
+            return;
+        }
+
+        const taskToken = Symbol();
+        this.#activeTasks.set(key, taskToken);
+
+        return Promise.resolve().then(task).finally(() => {
+            if (this.#activeTasks.get(key) === taskToken) {
+                this.#activeTasks.delete(key);
+            }
+        });
+    }
+}

--- a/src/util/exclusiveTaskRunner.ts
+++ b/src/util/exclusiveTaskRunner.ts
@@ -9,10 +9,16 @@ export class ExclusiveTaskRunner<Key> {
         const taskToken = Symbol();
         this.#activeTasks.set(key, taskToken);
 
-        return Promise.resolve().then(task).finally(() => {
+        return this.#runTask(key, taskToken, task);
+    }
+
+    async #runTask(key: Key, taskToken: symbol, task: () => Promise<void>): Promise<void> {
+        try {
+            await task();
+        } finally {
             if (this.#activeTasks.get(key) === taskToken) {
                 this.#activeTasks.delete(key);
             }
-        });
+        }
     }
 }

--- a/test/exclusiveTaskRunner.test.js
+++ b/test/exclusiveTaskRunner.test.js
@@ -1,0 +1,54 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { ExclusiveTaskRunner } = require("../dist/util/exclusiveTaskRunner");
+
+test("runs only one task per key while retaining parallelism across keys", async () => {
+    const runner = new ExclusiveTaskRunner();
+    let releaseFirstTask;
+    let replacementRuns = 0;
+    let parallelRuns = 0;
+
+    const firstTask = runner.run(
+        "guild-a",
+        () =>
+            new Promise((resolve) => {
+                releaseFirstTask = resolve;
+            })
+    );
+    const staleReplacement = runner.run("guild-a", async () => {
+        replacementRuns += 1;
+    });
+    const parallelTask = runner.run("guild-b", async () => {
+        parallelRuns += 1;
+    });
+
+    assert.ok(firstTask);
+    assert.equal(staleReplacement, undefined);
+    assert.ok(parallelTask);
+    await parallelTask;
+    assert.equal(parallelRuns, 1);
+
+    releaseFirstTask();
+    await firstTask;
+
+    const replacementTask = runner.run("guild-a", async () => {
+        replacementRuns += 1;
+    });
+    assert.ok(replacementTask);
+    await replacementTask;
+    assert.equal(replacementRuns, 1);
+});
+
+test("releases the key when a task fails", async () => {
+    const runner = new ExclusiveTaskRunner();
+
+    const failedTask = runner.run("guild-a", async () => {
+        throw new Error("tick failed");
+    });
+    assert.ok(failedTask);
+    await assert.rejects(failedTask, /tick failed/);
+
+    const retryTask = runner.run("guild-a", async () => {});
+    assert.ok(retryTask);
+    await retryTask;
+});


### PR DESCRIPTION
## Summary
- coalesce timer ticks while the same guild already has one in flight
- retain parallel timer processing across different guilds
- release the per-guild guard after success or failure, with token-checked cleanup
- add focused tests for overlap suppression, cross-guild parallelism, replacement behavior, and failure recovery

## Rationale
The one-second scheduler previously launched each guild tick without backpressure. When voice, Discord, or persistence work took longer than one second, more work for that guild accumulated and increased CPU usage. The scheduler still runs every second; a busy guild skips intermediate attempts and the next accepted tick uses the current wall-clock time for its countdown.

## Validation
- npm test
- git diff --check