### PR TITLE
fix(discord): bound gateway caches

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -7,21 +7,24 @@ import {
     Partials,
 } from "discord.js";
 
-const CACHE_SWEEP_INTERVAL = 5 * 60;
+const CACHE_SWEEP_INTERVAL = 5 * 60; // 5 minutes
 
 const isClientUser = ({ client, id }: { client: Client; id: string }) => client.user?.id === id;
 
 const cacheLimits = {
     ...Options.DefaultMakeCacheSettings,
     GuildMemberManager: {
+        // Unbounded by default.
         maxSize: 200,
         keepOverLimit: (member) => isClientUser(member) || member.voice.channelId !== null,
     },
     UserManager: {
+        // Unbounded by default.
         maxSize: 1_000,
         keepOverLimit: isClientUser,
     },
     VoiceStateManager: {
+        // Unbounded by default.
         maxSize: 200,
         keepOverLimit: (voiceState) => isClientUser(voiceState) || voiceState.channelId !== null,
     },
@@ -50,19 +53,19 @@ export const client = new Client({
     sweepers: {
         ...Options.DefaultSweeperSettings,
         guildMembers: {
-            interval: CACHE_SWEEP_INTERVAL,
+            interval: CACHE_SWEEP_INTERVAL, // 5 minutes
             filter: () => (member) => !isClientUser(member) && member.voice.channelId === null,
         },
         messages: {
-            interval: CACHE_SWEEP_INTERVAL,
-            lifetime: 30 * 60,
+            interval: CACHE_SWEEP_INTERVAL, // 5 minutes
+            lifetime: 30 * 60, // 30 minutes
         },
         users: {
-            interval: CACHE_SWEEP_INTERVAL,
+            interval: CACHE_SWEEP_INTERVAL, // 5 minutes
             filter: () => (user) => !isClientUser(user),
         },
         voiceStates: {
-            interval: CACHE_SWEEP_INTERVAL,
+            interval: CACHE_SWEEP_INTERVAL, // 5 minutes
             filter: () => (voiceState) => !isClientUser(voiceState) && voiceState.channelId === null,
         },
     },

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1,6 +1,34 @@
-import { ActivityType, Client, IntentsBitField, Partials } from "discord.js";
+import {
+    ActivityType,
+    type CacheWithLimitsOptions,
+    Client,
+    IntentsBitField,
+    Options,
+    Partials,
+} from "discord.js";
+
+const CACHE_SWEEP_INTERVAL = 5 * 60;
+
+const isClientUser = ({ client, id }: { client: Client; id: string }) => client.user?.id === id;
+
+const cacheLimits = {
+    ...Options.DefaultMakeCacheSettings,
+    GuildMemberManager: {
+        maxSize: 200,
+        keepOverLimit: (member) => isClientUser(member) || member.voice.channelId !== null,
+    },
+    UserManager: {
+        maxSize: 1_000,
+        keepOverLimit: isClientUser,
+    },
+    VoiceStateManager: {
+        maxSize: 200,
+        keepOverLimit: (voiceState) => isClientUser(voiceState) || voiceState.channelId !== null,
+    },
+} satisfies CacheWithLimitsOptions;
 
 export const client = new Client({
+    makeCache: Options.cacheWithLimits(cacheLimits),
     presence: {
         afk: false,
         activities: [
@@ -18,5 +46,24 @@ export const client = new Client({
         IntentsBitField.Flags.GuildVoiceStates,
         IntentsBitField.Flags.DirectMessages,
     ],
-    partials: [Partials.Channel, Partials.Message, Partials.Reaction],
+    partials: [Partials.Channel, Partials.Message, Partials.Reaction, Partials.User],
+    sweepers: {
+        ...Options.DefaultSweeperSettings,
+        guildMembers: {
+            interval: CACHE_SWEEP_INTERVAL,
+            filter: () => (member) => !isClientUser(member) && member.voice.channelId === null,
+        },
+        messages: {
+            interval: CACHE_SWEEP_INTERVAL,
+            lifetime: 30 * 60,
+        },
+        users: {
+            interval: CACHE_SWEEP_INTERVAL,
+            filter: () => (user) => !isClientUser(user),
+        },
+        voiceStates: {
+            interval: CACHE_SWEEP_INTERVAL,
+            filter: () => (voiceState) => !isClientUser(voiceState) && voiceState.channelId === null,
+        },
+    },
 });

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -51,7 +51,7 @@ export const client = new Client({
     ],
     partials: [Partials.Channel, Partials.Message, Partials.Reaction, Partials.User],
     sweepers: {
-        ...Options.DefaultSweeperSettings,
+        ...Options.DefaultSweeperSettings, // Every hour, removes archived threads older than 4 hours.
         guildMembers: {
             interval: CACHE_SWEEP_INTERVAL, // 5 minutes
             filter: () => (member) => !isClientUser(member) && member.voice.channelId === null,


### PR DESCRIPTION
## Summary

- cap guild member, user, and voice-state caches
- sweep disconnected members, stale users, stale voice states, and old messages
- preserve the bot and all active voice participants above cache limits
- enable user partials so reaction removal continues after a user cache entry is swept

## Rationale

Discord.js only bounds message caches by default. Long-lived processes therefore retain observed users and guild members indefinitely. These conservative limits and sweepers bound that growth without evicting active voice participants. ChannelManager is intentionally unchanged because discord.js marks overriding its cache as unsupported.

## Validation

- npm run build
- focused runtime assertions for cache sizes, preservation predicates, partials, and sweeper intervals
- git diff --check