### PR TITLE
fix(discord): avoid fetching partial reactions

### DIFF
--- a/src/handlers/messageReactionAdd/index.ts
+++ b/src/handlers/messageReactionAdd/index.ts
@@ -13,14 +13,6 @@ export async function handleMessageReactionAdd({
     args: [messageReaction, user],
     scope,
 }: HandlerProps<[MessageReaction, User | PartialUser]>) {
-    if (messageReaction.partial) {
-        try {
-            await messageReaction.fetch();
-        } catch {
-            return;
-        }
-    }
-
     if (user.id === client.user!.id) {
         return;
     }
@@ -41,6 +33,15 @@ export async function handleMessageReactionAdd({
         timer.status?.messageId !== messageReaction.message.id
     ) {
         return;
+    }
+
+    // Only fetch reactions for the active timer's status message.
+    if (messageReaction.partial) {
+        try {
+            await messageReaction.fetch();
+        } catch {
+            return;
+        }
     }
 
     logger.info(messageReaction.message.guild!.id, `Message Reaction Add: ${messageReaction.emoji.name}`);

--- a/src/handlers/messageReactionAdd/index.ts
+++ b/src/handlers/messageReactionAdd/index.ts
@@ -1,4 +1,4 @@
-import { MessageReaction, PartialUser, User } from "discord.js";
+import { MessageReaction, PartialMessageReaction, PartialUser, User } from "discord.js";
 import { client } from "../../discord";
 import { configRepo } from "../../persistence";
 import { timerRepo } from "../../persistence";
@@ -12,7 +12,7 @@ import { EMOJI_PLUS10, EMOJI_SKIP, EMOJI_TOAST } from "../../util/emojis";
 export async function handleMessageReactionAdd({
     args: [messageReaction, user],
     scope,
-}: HandlerProps<[MessageReaction, User | PartialUser]>) {
+}: HandlerProps<[MessageReaction | PartialMessageReaction, User | PartialUser]>) {
     if (user.id === client.user!.id) {
         return;
     }
@@ -33,15 +33,6 @@ export async function handleMessageReactionAdd({
         timer.status?.messageId !== messageReaction.message.id
     ) {
         return;
-    }
-
-    // Only fetch reactions for the active timer's status message.
-    if (messageReaction.partial) {
-        try {
-            await messageReaction.fetch();
-        } catch {
-            return;
-        }
     }
 
     logger.info(messageReaction.message.guild!.id, `Message Reaction Add: ${messageReaction.emoji.name}`);
@@ -84,7 +75,7 @@ export async function handleMessageReactionAdd({
     }
 }
 
-async function removeReaction(messageReaction: MessageReaction, user: User | PartialUser) {
+async function removeReaction(messageReaction: MessageReaction | PartialMessageReaction, user: User | PartialUser) {
     if (hasManageMessagesPermissions(messageReaction.message.guild!)) {
         try {
             await messageReaction.users.remove(user.id);

--- a/src/handlers/messageReactionRemove/index.ts
+++ b/src/handlers/messageReactionRemove/index.ts
@@ -12,14 +12,6 @@ export async function handleMessageReactionRemove({
     args: [messageReaction, user],
     scope,
 }: HandlerProps<[MessageReaction, User | PartialUser]>) {
-    if (messageReaction.partial) {
-        try {
-            await messageReaction.fetch();
-        } catch {
-            return;
-        }
-    }
-
     if (user.id === client.user!.id) {
         return;
     }
@@ -40,6 +32,15 @@ export async function handleMessageReactionRemove({
         timer.status?.messageId !== messageReaction.message.id
     ) {
         return;
+    }
+
+    // Only fetch reactions for the active timer's status message.
+    if (messageReaction.partial) {
+        try {
+            await messageReaction.fetch();
+        } catch {
+            return;
+        }
     }
 
     logger.info(messageReaction.message.guild!.id, `Message Reaction Remove: ${messageReaction.emoji.name}`);

--- a/src/handlers/messageReactionRemove/index.ts
+++ b/src/handlers/messageReactionRemove/index.ts
@@ -1,4 +1,4 @@
-import { MessageReaction, PartialUser, User } from "discord.js";
+import { MessageReaction, PartialMessageReaction, PartialUser, User } from "discord.js";
 import { client } from "../../discord";
 import { configRepo } from "../../persistence";
 import { timerRepo } from "../../persistence";
@@ -11,7 +11,7 @@ import { EMOJI_TOAST } from "../../util/emojis";
 export async function handleMessageReactionRemove({
     args: [messageReaction, user],
     scope,
-}: HandlerProps<[MessageReaction, User | PartialUser]>) {
+}: HandlerProps<[MessageReaction | PartialMessageReaction, User | PartialUser]>) {
     if (user.id === client.user!.id) {
         return;
     }
@@ -32,15 +32,6 @@ export async function handleMessageReactionRemove({
         timer.status?.messageId !== messageReaction.message.id
     ) {
         return;
-    }
-
-    // Only fetch reactions for the active timer's status message.
-    if (messageReaction.partial) {
-        try {
-            await messageReaction.fetch();
-        } catch {
-            return;
-        }
     }
 
     logger.info(messageReaction.message.guild!.id, `Message Reaction Remove: ${messageReaction.emoji.name}`);


### PR DESCRIPTION
Reaction handlers currently fetch messages for partial reactions even though timer controls only need the message/channel/guild IDs, emoji, and reacting user ID already supplied by the event. This adds unnecessary Discord REST requests for both unrelated traffic and timer reactions.

Remove the partial-reaction fetch from both reaction-add and reaction-remove handlers, and explicitly accept partial reaction types. Timer actions and user-reaction removal operate directly on the event data.

Validation:
- `npm test`: TypeScript build and both existing tests pass.
- 14 offline scenarios using real Discord.js reaction objects pass: self reactions, DMs, missing timers, mismatched channels/messages, and matching partial/cached reactions in both handlers.
- Verified partial user-reaction removal issues a DELETE without fetching the reaction/message.
- Prettier formatting and `git diff --check` pass.
